### PR TITLE
Add basic SPA with terminal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# devops-portfolio
-This is my minimal DevOps portfolio created with HUGO.
+# DevOps Portfolio
+
+This repository contains a minimal portfolio for showcasing DevOps work. It includes a simple Single Page Application (SPA) as well as a terminal style interface.
+
+- **SPA**: Located in `spa-portfolio/`. It provides a basic blog section and a showcase area. Use the navigation links to switch between sections. A button in the navigation opens the terminal version of the site.
+- **Terminal**: Located in `terminal-portfolio/`. This page mimics a terminal where you can use custom commands to explore information.
+
+Both versions are static HTML/CSS/JS and can be served with any web server.

--- a/spa-portfolio/css/styles.css
+++ b/spa-portfolio/css/styles.css
@@ -1,0 +1,41 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f7f7f7;
+  margin: 0;
+  padding: 0;
+}
+
+nav {
+  background-color: #333;
+  color: #fff;
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 10px;
+  text-decoration: none;
+}
+
+main {
+  padding: 20px;
+}
+
+.section {
+  display: none;
+}
+
+.section.active {
+  display: block;
+}
+
+button.terminal-btn {
+  background-color: #333;
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+}

--- a/spa-portfolio/index.html
+++ b/spa-portfolio/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>DevOps Portfolio SPA</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <nav>
+    <div>
+      <a href="#" data-target="home">Inicio</a>
+      <a href="#" data-target="blog">Blog</a>
+      <a href="#" data-target="showcase">Showcase</a>
+    </div>
+    <button class="terminal-btn" onclick="window.location.href='../terminal-portfolio/index.html'">Terminal</button>
+  </nav>
+
+  <main>
+    <section id="home" class="section">
+      <h1>Bienvenido a mi Portfolio DevOps</h1>
+      <p>Esta SPA muestra mi trabajo y artículos sobre DevOps.</p>
+    </section>
+
+    <section id="blog" class="section">
+      <h2>Blog</h2>
+      <article>
+        <h3>Primer Post</h3>
+        <p>Contenido de ejemplo para el blog. Aquí podrás compartir tus ideas sobre DevOps y tecnología.</p>
+      </article>
+    </section>
+
+    <section id="showcase" class="section">
+      <h2>Showcase</h2>
+      <p>Aquí puedes mostrar tus proyectos y experiencia profesional.</p>
+    </section>
+  </main>
+
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/spa-portfolio/js/app.js
+++ b/spa-portfolio/js/app.js
@@ -1,0 +1,23 @@
+function showSection(id) {
+  document.querySelectorAll('.section').forEach(sec => sec.classList.remove('active'));
+  const active = document.getElementById(id);
+  if (active) {
+    active.classList.add('active');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Setup navigation links
+  document.querySelectorAll('nav a').forEach(link => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const target = link.getAttribute('data-target');
+      if (target) {
+        showSection(target);
+      }
+    });
+  });
+
+  // Show home by default
+  showSection('home');
+});


### PR DESCRIPTION
## Summary
- add a simple SPA with blog and showcase sections
- link to existing terminal portfolio from the SPA
- document both versions in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d9ee9209883269fa54b35e46e4976